### PR TITLE
Fix setup.py to install the sub-packages in the "gacha" package/directory

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setuptools.setup(
     name="gacha-rexor12",
-    version="1.0.1",
+    version="1.0.2",
     author="rexor12",
     author_email="rrexor@gmail.com",
     description="Generic gacha system for games.",
@@ -16,10 +16,7 @@ setuptools.setup(
     project_urls={
         "Issue tracker": "https://github.com/rexor12/gacha/issues"
     },
-    packages=setuptools.find_packages(where="gacha"),
-    package_dir={
-        "": "gacha"
-    },
+    packages=[ "gacha" ],
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Fixes the issue introduced by #2, that is, the sub-packages are extracted directly to site-packages instead of the containing package "gacha".